### PR TITLE
Added option for PaneByFillMode and fixed HotbarNumberClick bug

### DIFF
--- a/bukkit/src/main/java/com/github/dig/endervaults/bukkit/BukkitListener.java
+++ b/bukkit/src/main/java/com/github/dig/endervaults/bukkit/BukkitListener.java
@@ -9,16 +9,13 @@ import com.github.dig.endervaults.bukkit.vault.BukkitVaultRegistry;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryDragEvent;
-import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.inventory.*;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -26,10 +23,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitTask;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class BukkitListener implements Listener {
@@ -65,13 +59,24 @@ public class BukkitListener implements Listener {
         Player player = (Player) event.getWhoClicked();
 
         BukkitVaultRegistry registry = (BukkitVaultRegistry) plugin.getRegistry();
-        ItemStack item = event.getCurrentItem();
+        ArrayList<ItemStack> items = new ArrayList<>();
+        items.add(event.getCurrentItem());
         Inventory inventory = event.getInventory();
 
-        if (inventory != null && item != null && isBlacklistEnabled()) {
-            if (!permission.canBypassBlacklist(player) && getBlacklisted().contains(item.getType()) && registry.isVault(inventory)) {
-                player.sendMessage(plugin.getLanguage().get(Lang.BLACKLISTED_ITEM));
-                event.setCancelled(true);
+        if(event.getClick() == ClickType.NUMBER_KEY) {
+            items.add(player.getInventory().getItem(event.getHotbarButton()));
+        }
+
+        if (inventory != null && isBlacklistEnabled()) {
+            if(permission.canBypassBlacklist(player)) return;
+            if(!registry.isVault(inventory)) return;
+
+            for(ItemStack item : items) {
+                if (item != null && getBlacklisted().contains(item.getType())) {
+                    player.sendMessage(plugin.getLanguage().get(Lang.BLACKLISTED_ITEM));
+                    event.setCancelled(true);
+                    return;
+                }
             }
         }
     }

--- a/bukkit/src/main/java/com/github/dig/endervaults/bukkit/ui/icon/SelectIconBuilder.java
+++ b/bukkit/src/main/java/com/github/dig/endervaults/bukkit/ui/icon/SelectIconBuilder.java
@@ -1,0 +1,36 @@
+package com.github.dig.endervaults.bukkit.ui.icon;
+
+import com.github.dig.endervaults.api.selector.SelectorMode;
+import com.github.dig.endervaults.api.vault.Vault;
+import de.tr7zw.changeme.nbtapi.NBTItem;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class SelectIconBuilder {
+
+
+    public static NBTItem fromMaterial(Vault vault, Material material) {
+        return fromMaterial(vault, material, SelectorMode.STATIC);
+    }
+
+    public static NBTItem fromMaterial(Vault vault, Material material, SelectorMode selectorMode) {
+        ItemStack item = new ItemStack(material, 1);
+        ItemMeta meta = item.getItemMeta();
+        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES,
+                ItemFlag.HIDE_UNBREAKABLE,
+                ItemFlag.HIDE_ENCHANTS,
+                ItemFlag.HIDE_DESTROYS,
+                ItemFlag.HIDE_POTION_EFFECTS,
+                ItemFlag.HIDE_PLACED_ON);
+        item.setItemMeta(meta);
+
+        NBTItem nbtItem = new NBTItem(item);
+        nbtItem.setBoolean(SelectIconConstants.NBT_ICON_ITEM, true);
+        nbtItem.setString(SelectIconConstants.NBT_ICON_ID, vault.getId().toString());
+        nbtItem.setString(SelectIconConstants.NBT_ICON_OWNER_UUID, vault.getOwner().toString());
+        nbtItem.setString(SelectIconConstants.NBT_ICON_SELECTOR_MODE, selectorMode.name());
+        return nbtItem;
+    }
+}

--- a/bukkit/src/main/java/com/github/dig/endervaults/bukkit/ui/icon/SelectIconConstants.java
+++ b/bukkit/src/main/java/com/github/dig/endervaults/bukkit/ui/icon/SelectIconConstants.java
@@ -5,5 +5,5 @@ public class SelectIconConstants {
     public final static String NBT_ICON_ITEM = "vaulticonitem";
     public final static String NBT_ICON_ID = "vaulticonid";
     public final static String NBT_ICON_OWNER_UUID = "vaulticonowneruuid";
-
+    public final static String NBT_ICON_SELECTOR_MODE = "vaulticonselectormode";
 }

--- a/bukkit/src/main/java/com/github/dig/endervaults/bukkit/ui/icon/SelectIconInventory.java
+++ b/bukkit/src/main/java/com/github/dig/endervaults/bukkit/ui/icon/SelectIconInventory.java
@@ -2,6 +2,7 @@ package com.github.dig.endervaults.bukkit.ui.icon;
 
 import com.github.dig.endervaults.api.VaultPluginProvider;
 import com.github.dig.endervaults.api.lang.Lang;
+import com.github.dig.endervaults.api.selector.SelectorMode;
 import com.github.dig.endervaults.api.vault.Vault;
 import com.github.dig.endervaults.bukkit.EVBukkitPlugin;
 import de.tr7zw.changeme.nbtapi.NBTItem;
@@ -35,36 +36,35 @@ public class SelectIconInventory {
     }
 
     private void init() {
+        int slot;
+        Material material;
         for (String matName : configuration.getStringList("selector.select-icon.items")) {
-            Material material;
             try {
                 material = Material.valueOf(matName);
             } catch (IllegalArgumentException e) {
                 log.log(Level.SEVERE, "[EnderVaults] Unable to find material " + matName + ", skipping...", e);
                 continue;
             }
-
-            ItemStack item = new ItemStack(material, 1);
-            ItemMeta meta = item.getItemMeta();
-            meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES,
-                    ItemFlag.HIDE_UNBREAKABLE,
-                    ItemFlag.HIDE_ENCHANTS,
-                    ItemFlag.HIDE_DESTROYS,
-                    ItemFlag.HIDE_POTION_EFFECTS,
-                    ItemFlag.HIDE_PLACED_ON);
-            item.setItemMeta(meta);
-
-            NBTItem nbtItem = new NBTItem(item);
-            nbtItem.setBoolean(SelectIconConstants.NBT_ICON_ITEM, true);
-            nbtItem.setString(SelectIconConstants.NBT_ICON_ID, vault.getId().toString());
-            nbtItem.setString(SelectIconConstants.NBT_ICON_OWNER_UUID, vault.getOwner().toString());
-
-            int slot = inventory.firstEmpty();
-            if (slot > -1) {
-                inventory.setItem(inventory.firstEmpty(), nbtItem.getItem());
-            } else {
-                log.log(Level.INFO, "[EnderVaults] Unable to find available spot to put item in, please reconfigure select icon settings.");
+            slot = inventory.firstEmpty();
+            addItemAt(SelectIconBuilder.fromMaterial(vault, material, SelectorMode.STATIC), slot);
+        }
+        for (String matName : configuration.getStringList("selector.select-icon.pane_fill_item")) {
+            try {
+                material = Material.valueOf(matName);
+            } catch (IllegalArgumentException e) {
+                log.log(Level.SEVERE, "[EnderVaults] Unable to find material " + matName + ", skipping...", e);
+                continue;
             }
+            slot = inventory.firstEmpty();
+            addItemAt(SelectIconBuilder.fromMaterial(vault, material, SelectorMode.PANE_BY_FILL), slot);
+        }
+    }
+
+    private void addItemAt(NBTItem nbtItem, int slot) {
+        if (slot > -1) {
+            inventory.setItem(inventory.firstEmpty(), nbtItem.getItem());
+        } else {
+            log.log(Level.INFO, "[EnderVaults] Unable to find available spot to put item in, please reconfigure select icon settings.");
         }
     }
 

--- a/bukkit/src/main/java/com/github/dig/endervaults/bukkit/ui/icon/SelectIconListener.java
+++ b/bukkit/src/main/java/com/github/dig/endervaults/bukkit/ui/icon/SelectIconListener.java
@@ -1,6 +1,8 @@
 package com.github.dig.endervaults.bukkit.ui.icon;
 
 import com.github.dig.endervaults.api.VaultPluginProvider;
+import com.github.dig.endervaults.api.selector.SelectorMode;
+import com.github.dig.endervaults.api.vault.Vault;
 import com.github.dig.endervaults.api.vault.VaultRegistry;
 import com.github.dig.endervaults.api.vault.metadata.VaultDefaultMetadata;
 import com.github.dig.endervaults.bukkit.ui.selector.SelectorInventory;
@@ -33,8 +35,16 @@ public class SelectIconListener implements Listener {
                 event.setCancelled(true);
                 UUID vaultID = UUID.fromString(nbtItem.getString(SelectIconConstants.NBT_ICON_ID));
                 UUID vaultOwnerUUID = UUID.fromString(nbtItem.getString(SelectIconConstants.NBT_ICON_OWNER_UUID));
+                SelectorMode selectorMode = SelectorMode.valueOf(nbtItem.getString(SelectIconConstants.NBT_ICON_SELECTOR_MODE));
 
-                registry.get(vaultOwnerUUID, vaultID).ifPresent(vault -> vault.getMetadata().put(VaultDefaultMetadata.ICON.getKey(), item.getType().toString()));
+                switch(selectorMode) {
+                    case STATIC: {
+                        registry.get(vaultOwnerUUID, vaultID).ifPresent(vault -> vault.getMetadata().put(VaultDefaultMetadata.ICON.getKey(), item.getType().toString()));
+                    }
+                    case PANE_BY_FILL: {
+                        registry.get(vaultOwnerUUID, vaultID).ifPresent(vault -> vault.getMetadata().remove(VaultDefaultMetadata.ICON.getKey()));
+                    }
+                }
                 new SelectorInventory(vaultOwnerUUID, 1).launchFor(player);
             }
         }

--- a/bukkit/src/main/java/com/github/dig/endervaults/bukkit/ui/icon/SelectIconListener.java
+++ b/bukkit/src/main/java/com/github/dig/endervaults/bukkit/ui/icon/SelectIconListener.java
@@ -40,9 +40,11 @@ public class SelectIconListener implements Listener {
                 switch(selectorMode) {
                     case STATIC: {
                         registry.get(vaultOwnerUUID, vaultID).ifPresent(vault -> vault.getMetadata().put(VaultDefaultMetadata.ICON.getKey(), item.getType().toString()));
+                        break;
                     }
                     case PANE_BY_FILL: {
                         registry.get(vaultOwnerUUID, vaultID).ifPresent(vault -> vault.getMetadata().remove(VaultDefaultMetadata.ICON.getKey()));
+                        break;
                     }
                 }
                 new SelectorInventory(vaultOwnerUUID, 1).launchFor(player);

--- a/bukkit/src/main/java/com/github/dig/endervaults/bukkit/ui/selector/SelectorListener.java
+++ b/bukkit/src/main/java/com/github/dig/endervaults/bukkit/ui/selector/SelectorListener.java
@@ -106,11 +106,4 @@ public class SelectorListener implements Listener {
             event.setCancelled(true);
         }
     }
-
-    @EventHandler(priority = EventPriority.HIGH)
-    public void onDrag(InventoryInteractEvent event) {
-        if (event.getView().getTopInventory().getHolder() instanceof SelectorInventory) {
-            event.setCancelled(true);
-        }
-    }
 }

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -70,7 +70,9 @@ selector:
       - ARROW
       - APPLE
       - WHEAT
-  # Item designs, how the items look etc.
+    # Item designs, how the items look etc.
+    pane_fill_item:
+      - WHITE_STAINED_GLASS_PANE
   template:
     # Unlocked vault item
     unlocked:


### PR DESCRIPTION
+ Added refractored code to add support for multiple SelectorModes
+ Added selector.select-icon.pane_fill_item this is used to add one or more PaneByFill SelectorIcons
+ Added SelectIconBuilder.java to centralize the creation of SelectorIcons
+ Players can now click on the WhiteStainedGlassPane to get the PaneByFill Icon back
+ Players can no longer bypass the blacklist by using hotbar number clicks

Adding a Material to selector.select-icon.pane_fill_item in config.yml will create a new Selectable Icon which sets the mode of the page back to display the percentage filled in the vault.